### PR TITLE
HTTPClient changes

### DIFF
--- a/MSGraphClientSDK/MSGraphClientSDK/Common/MSConstants.h
+++ b/MSGraphClientSDK/MSGraphClientSDK/Common/MSConstants.h
@@ -53,6 +53,10 @@ typedef NS_ENUM(NSInteger, MSMiddlewareOptionsType)
 };
 
 extern NSString *const MSGraphBaseURL;
+extern NSString *const MSGraphChinaBaseURL;
+extern NSString *const MSGraphUSBaseURL;
+extern NSString *const MSGraphGermanyBaseURL;
+
 extern NSString *const MSHeaderSdkVersion;
 extern NSString *const MSGraphiOSSdkVersionHeaderPrefix;
 extern NSString *const MSGraphMacSdkVersionHeaderPrefix;

--- a/MSGraphClientSDK/MSGraphClientSDK/Common/MSConstants.m
+++ b/MSGraphClientSDK/MSGraphClientSDK/Common/MSConstants.m
@@ -4,7 +4,11 @@
 
 #import "MSConstants.h"
 
-NSString *const MSGraphBaseURL = @"https://graph.microsoft.com/v1.0";
+NSString *const MSGraphBaseURL              = @"https://graph.microsoft.com/v1.0";
+NSString *const MSGraphChinaBaseURL         = @"https://microsoftgraph.chinacloudapi.cn/v1.0";
+NSString *const MSGraphUSBaseURL            = @"https://graph.microsoft.us/v1.0";
+NSString *const MSGraphGermanyBaseURL       = @"https://graph.microsoft.de/v1.0";
+
 NSString *const MSHeaderSdkVersion = @"SdkVersion";
 NSString *const MSGraphiOSSdkVersionHeaderPrefix = @"graph-objc-ios-";
 NSString *const MSGraphMacSdkVersionHeaderPrefix = @"graph-objc-mac-";

--- a/MSGraphClientSDK/MSGraphClientSDK/HTTPClient/MSClientFactory.h
+++ b/MSGraphClientSDK/MSGraphClientSDK/HTTPClient/MSClientFactory.h
@@ -12,15 +12,24 @@
  Initializes and returns an instance of MSHTTPClient class with a default chain of middleware to handle the HTTP calls.
 
  @param authenticationProvider Instance of the class which implements the methods of MSAuthenticationProvider
- @param baseUrl Base URL of all the network calls which will be made my this client.
+ @return MSHTTPClient instance
  */
 
 +(MSHTTPClient *)createHTTPClientWithAuthenticationProvider:(id<MSAuthenticationProvider>)authenticationProvider;
 
 /*
+ Initializes and returns an instance of MSHTTPClient class with a default chain of middleware to handle the HTTP calls.
+
+ @param authenticationProvider Instance of the class which implements the methods of MSAuthenticationProvider
+ @param sessionConfiguration Instance of NSURLSessionConfiguration which will be used to create the NSURLSession for this client Instance.
+ @return MSHTTPClient instance
+ */
++(MSHTTPClient *)createHTTPClientWithAuthenticationProvider:(id<MSAuthenticationProvider>)authenticationProvider andSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration;
+/*
  Initializes and returns an instance of MSHTTPClient class with a custom chain of middleware to handle the HTTP calls.
 
  @param middleware Instance of a class which will be the first node in the custom chain of middleware.
+ @return MSHTTPClient instance
  */
 
 +(MSHTTPClient *)createHTTPClientWithMiddleware:(id<MSGraphMiddleware>)middleware;

--- a/MSGraphClientSDK/MSGraphClientSDK/HTTPClient/MSClientFactory.m
+++ b/MSGraphClientSDK/MSGraphClientSDK/HTTPClient/MSClientFactory.m
@@ -31,6 +31,30 @@
     return [MSClientFactory createHTTPClientWithMiddleware:authenticationHandler];
 }
 
++(MSHTTPClient *)createHTTPClientWithAuthenticationProvider:(id<MSAuthenticationProvider>)authenticationProvider andSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration
+{
+    NSParameterAssert(authenticationProvider);
+    NSParameterAssert(sessionConfiguration);
+
+    //Creating a default chain of middlewares starting from Authentication
+
+    //Initializing different default middlewares
+    MSAuthenticationHandler *authenticationHandler = (MSAuthenticationHandler *)[MSMiddlewareFactory createMiddleware:MSMiddlewareTypeAuthentication];
+    authenticationHandler.authProvider = authenticationProvider;
+    MSRedirectHandler *redirectHandler = (MSRedirectHandler *)[MSMiddlewareFactory createMiddleware:MSMiddlewareTypeRedirect];
+    MSRetryHandler *retryHandler = (MSRetryHandler *)[MSMiddlewareFactory createMiddleware:MSMiddlewareTypeRetry];
+
+    //Create session manager with custom session configuration
+    MSURLSessionManager *sessionManager = [[MSURLSessionManager alloc] initWithSessionConfiguration:sessionConfiguration];
+
+    //Creating a default chain
+    [authenticationHandler setNext:redirectHandler];
+    [redirectHandler setNext:retryHandler];
+    [retryHandler setNext:sessionManager];
+
+    return [MSClientFactory createHTTPClientWithMiddleware:authenticationHandler];
+}
+
 +(MSHTTPClient *)createHTTPClientWithMiddleware:(id<MSGraphMiddleware>)middleware
 {
     NSParameterAssert(middleware);

--- a/MSGraphClientSDK/MSGraphClientSDK/HTTPClient/MSMiddlewareFactory.m
+++ b/MSGraphClientSDK/MSGraphClientSDK/HTTPClient/MSMiddlewareFactory.m
@@ -16,7 +16,7 @@
     {
         case MSMiddlewareTypeHTTP:
         {
-             MSURLSessionManager *sessionManager = [[MSURLSessionManager alloc] initWithSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+             MSURLSessionManager *sessionManager = [[MSURLSessionManager alloc] init];
             return sessionManager;
         }
         case MSMiddlewareTypeRedirect:

--- a/MSGraphClientSDK/MSGraphClientSDK/Middleware/Implementations/HTTPProvider/MSURLSessionManager.m
+++ b/MSGraphClientSDK/MSGraphClientSDK/Middleware/Implementations/HTTPProvider/MSURLSessionManager.m
@@ -42,6 +42,13 @@
 
 @implementation MSURLSessionManager
 
+- (instancetype)init
+{
+    NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    sessionConfiguration.timeoutIntervalForRequest = 100;
+    return [self initWithSessionConfiguration:sessionConfiguration];
+}
+
 - (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)urlSessionConfiguration
 {
     self = [super init];

--- a/MSGraphClientSDK/MSGraphClientSDKTests/HTTPClient/MSClientFactoryTests.m
+++ b/MSGraphClientSDK/MSGraphClientSDKTests/HTTPClient/MSClientFactoryTests.m
@@ -21,14 +21,25 @@
     [super tearDown];
 }
 
-- (void)testCreationOfHTTPClient{
+- (void)testCreationOfHTTPClientWithNilValue {
     XCTAssertThrows([MSClientFactory createHTTPClientWithAuthenticationProvider:nil]);
     XCTAssertThrows([MSClientFactory createHTTPClientWithMiddleware:nil]);
+    XCTAssertThrows([MSClientFactory createHTTPClientWithAuthenticationProvider:self.mockAuthProvider andSessionConfiguration:nil]);
+}
 
+- (void)testCreationOfHTTPClientWithAuthProvider {
     MSHTTPClient *defaulClient = [MSClientFactory createHTTPClientWithAuthenticationProvider:self.mockAuthProvider];
     XCTAssertNotNil(defaulClient);
+}
 
+- (void)testCreationOfHTTPClientWithMiddleware {
     MSHTTPClient *customClient = [MSClientFactory createHTTPClientWithMiddleware:OCMProtocolMock(@protocol(MSGraphMiddleware))];
     XCTAssertNotNil(customClient);
 }
+
+- (void)testCreationOfHTTPClientWithAuthProviderAndSessionConfiguration {
+    MSHTTPClient *defaulClient = [MSClientFactory createHTTPClientWithAuthenticationProvider:self.mockAuthProvider andSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    XCTAssertNotNil(defaulClient);
+}
+
 @end

--- a/MSGraphClientSDK/MSGraphClientSDKTests/Middleware/Implementations/MSURLSessionManagerTests.m
+++ b/MSGraphClientSDK/MSGraphClientSDKTests/Middleware/Implementations/MSURLSessionManagerTests.m
@@ -56,17 +56,36 @@
 
 }
 
+- (void)testMSURLSessionManagerInit {
+    MSURLSessionManager *sessionManager = [[MSURLSessionManager alloc] init];
+    XCTAssertEqual(sessionManager.urlSessionConfiguration.timeoutIntervalForRequest,100);
+}
+
 - (void)testMSURLSessionManagerInitWithNilconfig{
     MSURLSessionManager * sessionManager = [[MSURLSessionManager alloc] initWithSessionConfiguration:nil];
     XCTAssertNotNil(sessionManager);
     XCTAssertNotNil(sessionManager.urlSession.configuration);
     XCTAssertEqualObjects(sessionManager.urlSession.delegate, sessionManager);
 }
-- (void)testMSURLSessionManagerInit{
+- (void)testMSURLSessionManagerInitWithCustomConfig{
+    NSString* proxyHost = @"127.0.0.1";
+    NSNumber* proxyPort = [NSNumber numberWithInt: 8888];
+    //     Create an NSURLSessionConfiguration that uses the proxy
+    NSDictionary *proxyDict = @{
+                                @"HTTPSEnable":@1,
+                                @"HTTPSProxy":proxyHost,
+                                @"HTTPSPort":proxyPort
+                                };
     NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    config.connectionProxyDictionary = proxyDict;
+    config.timeoutIntervalForRequest = 10;
     MSURLSessionManager * sessionManager = [[MSURLSessionManager alloc] initWithSessionConfiguration:config];
     XCTAssertNotNil(sessionManager);
     XCTAssertNotNil(sessionManager.urlSessionConfiguration);
+    XCTAssertEqual([sessionManager.urlSessionConfiguration.connectionProxyDictionary objectForKey:@"HTTPSProxy"], proxyHost);
+    XCTAssertEqual([sessionManager.urlSessionConfiguration.connectionProxyDictionary objectForKey:@"HTTPSPort"], proxyPort);
+    XCTAssertEqual([sessionManager.urlSessionConfiguration.connectionProxyDictionary objectForKey:@"HTTPSEnable"], @1);
+    XCTAssertEqual([sessionManager.urlSessionConfiguration timeoutIntervalForRequest], 10);
     XCTAssertEqualObjects(sessionManager.urlSession.delegate, sessionManager);
 }
 


### PR DESCRIPTION
This PR contains work for :

- Default request timeout for default middleware chain
- Method to create HTTPClient with user provided NSURLSessionConfiguration for custom request timeout and proxy support.
- 3 more base URLs to support sovereign clouds to ease the request url making.